### PR TITLE
fix repository URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LarsDenBakker/dom-test-tils.git"
+    "url": "git+https://github.com/LarsDenBakker/dom-test-utils.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/LarsDenBakker/dom-test-tils/issues"
+    "url": "https://github.com/LarsDenBakker/dom-test-utils/issues"
   },
-  "homepage": "https://github.com/LarsDenBakker/dom-test-tils#readme",
+  "homepage": "https://github.com/LarsDenBakker/dom-test-utils#readme",
   "dependencies": {
     "bundled-deep-diff": "bundled-es-modules/deep-diff#1.0.2",
     "bundled-parse5": "bundled-es-modules/parse5#5.1.0",


### PR DESCRIPTION
Currently links are broken, I got 404 when opening from here https://www.npmjs.com/package/dom-test-utils

let's fix them :)